### PR TITLE
Add config option for SyncTimeout to get passed in and actually used.

### DIFF
--- a/src/Orleans.Redis.Common/RedisOptions.cs
+++ b/src/Orleans.Redis.Common/RedisOptions.cs
@@ -7,5 +7,10 @@ namespace Orleans.Configuration
     public class RedisOptions
     {
         public string ConnectionString { get; set; }
+        public int SyncTimeout { get; set; } = 5000;
+        public string ToConfigString()
+        {
+            return $"{ConnectionString},syncTimeout={SyncTimeout}";
+        }
     }
 }

--- a/src/Orleans.Storage.Redis/Providers/Storage/RedisGrainStorage.cs
+++ b/src/Orleans.Storage.Redis/Providers/Storage/RedisGrainStorage.cs
@@ -49,10 +49,10 @@ namespace Orleans.Storage
             _clusterOptions = clusterOptions.Value;
             _connectionMultiplexerFactory = connectionMultiplexerFactory;
         }
-
+        
         public async Task Init(CancellationToken ct)
         {
-            _connectionMultiplexer = await _connectionMultiplexerFactory.CreateAsync(_options.ConnectionString);
+            _connectionMultiplexer = await _connectionMultiplexerFactory.CreateAsync(_options.ToConfigString());
         }
 
         public Task Close(CancellationToken ct)

--- a/src/Orleans.Streaming.Redis/Storage/RedisDataManager.cs
+++ b/src/Orleans.Streaming.Redis/Storage/RedisDataManager.cs
@@ -71,7 +71,7 @@ namespace Orleans.Streaming.Redis.Storage
 
                 _logger.Debug("Initializing RedisDataManager with {QueueCacheSize} and connecting to {ConnectionString}", _options.QueueCacheSize, _options.ConnectionString);
 
-                _connectionMultiplexer = await _connectionMultiplexerFactory.CreateAsync(_options.ConnectionString);
+                _connectionMultiplexer = await _connectionMultiplexerFactory.CreateAsync(_options.ToConfigString());
 
                 if (ct.IsCancellationRequested) throw new TaskCanceledException();
             }


### PR DESCRIPTION
Now uses a connection string with parameters. Currently only SyncTimeout, but can be easily extended by modifying RedisOptions.